### PR TITLE
【Fixed】各種コマンド使用不可問題のため、gem pg 1.1.2 を 0.21.0へバージョンダウン

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.7.1'
 # Use postgresql as the database for Active Record
-gem 'pg'
+gem 'pg', '0.21.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     multi_json (1.13.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    pg (1.1.2)
+    pg (0.21.0)
     rack (1.6.10)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -157,7 +157,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails
-  pg
+  pg (= 0.21.0)
   rails (= 4.2.7.1)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'top/index'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
環境
rails 4.2.7.1
ruby 2.3.0p0
ActiveRecord 4.2.7.1
pg 1.1.2（指定無し）

ActiveRecordのverにより、pg 1.0.0以上が対応していない事で
generateコマンド、rakeコマンド等使用不可であった。

1.gem uninstall pgで1.1.2と1.0.0を消去
2.Gemfileへgem 'pg', '0.21.0'と指定
3.bundle install

generate、rake系コマンド動作確認済み。

