### PR TITLE
#13-2 Eventモデル、eventsテーブルの作成

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ActiveRecord::Base
+end

--- a/db/migrate/20181002065054_create_events.rb
+++ b/db/migrate/20181002065054_create_events.rb
@@ -1,0 +1,12 @@
+class CreateEvents < ActiveRecord::Migration
+  def change
+    create_table :events do |t|
+      t.string :title
+      t.text :content
+      t.text :requirement
+      t.integer :manager_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181001001552) do
+ActiveRecord::Schema.define(version: 20181002065054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "events", force: :cascade do |t|
+    t.string   "title"
+    t.text     "content"
+    t.text     "requirement"
+    t.integer  "manager_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  content: MyText
+  requirement: MyText
+  manager_id: 1
+
+two:
+  title: MyString
+  content: MyText
+  requirement: MyText
+  manager_id: 1

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#13-2

イベント用モデル、イベント情報用テーブルの作成

title:string：タイトル
content:text：内容etc
requirement:text：条件記載用のサブ
manager_id:integer：管理者（作成者）id、user用外部キー

rake db:migrate の実行をお願いします。