### PR TITLE
#13-3 User、Event間、1:多アソシエーション設定

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,3 @@
 class Event < ActiveRecord::Base
+  belongs_to :user, foreign_key: "manager_id"
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :events, foreign_key: "manager_id"
 end


### PR DESCRIPTION
#13-3

イベント作成、表示に必要なアソシエーションを設定
外部キーはmanager_idを設定。

設定後、仮データ登録し外部キーから呼び出し表示をコンソールで確認済み。