### PR TITLE
#13-5 イベント編集、削除機能追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,7 @@
 class EventsController < ApplicationController
+
+  before_action :set_event_id, only: [:edit, :update, :destroy]
+
   def index
     @events = Event.all
   end
@@ -8,7 +11,7 @@ class EventsController < ApplicationController
   end
 
   def create
-    @event = Event.new(params.require(:event).permit(:title, :content, :requirement))
+    @event = Event.new(event_params)
     @event.manager_id = current_user.id
 
     if @event.save
@@ -25,8 +28,24 @@ class EventsController < ApplicationController
   end
 
   def update
+    if @event.update(event_params)
+      redirect_to events_path, notice: "登録内容を変更しました！"
+    else
+      render 'edit'
+    end
   end
 
   def destroy
+    @event.destroy
+    redirect_to events_path, notice: "イベントを削除しました！"
   end
+
+  private
+    def event_params
+      params.require(:event).permit(:title, :content, :requirement)
+    end
+
+    def set_event_id
+      @event = Event.find(params[:id])
+    end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,5 @@
 class EventsController < ApplicationController
-
-  before_action :set_event_id, only: [:edit, :update, :destroy]
+  before_action :set_event_id, only: [:show, :edit, :update, :destroy]
 
   def index
     @events = Event.all

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,0 +1,12 @@
+<%= form_for(@event) do |event| %>
+  <%= event.label :title %>
+  <%= event.text_field :title, class: 'form-control' %>
+  <br>
+  <%= event.label :content %>
+  <%= event.text_field :content, class: 'form-control' %>
+  <br>
+  <%= event.label :requirement %>
+  <%= event.text_field :requirement, class: 'form-control' %>
+  <br>
+  <%= event.submit '登録', class: 'btn btn-primary btn-block' %>
+<% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,16 +1,6 @@
 <div class="container">
   <div class="row">
-    <%= form_for(@event) do |event| %>
-      <%= event.label :title %>
-      <%= event.text_field :title, class: 'form-control' %>
-      <br>
-      <%= event.label :content %>
-      <%= event.text_field :content, class: 'form-control' %>
-      <br>
-      <%= event.label :requirement %>
-      <%= event.text_field :requirement, class: 'form-control' %>
-      <br>
-      <%= event.submit '新規登録', class: 'btn btn-primary btn-block' %>
-    <% end %>
+    <h2>イベント内容編集</h2>
+    <%= render 'form' %>
   </div>
 </div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="container">
+  <div class="row">
+    <%= form_for(@event) do |event| %>
+      <%= event.label :title %>
+      <%= event.text_field :title, class: 'form-control' %>
+      <br>
+      <%= event.label :content %>
+      <%= event.text_field :content, class: 'form-control' %>
+      <br>
+      <%= event.label :requirement %>
+      <%= event.text_field :requirement, class: 'form-control' %>
+      <br>
+      <%= event.submit '新規登録', class: 'btn btn-primary btn-block' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,23 +1,22 @@
 <div class="container">
   <div class="row">
     <h1>イベント一覧ページ</h1>
+    <%= link_to "イベント新規登録", new_event_path, class: 'btn btn-default' %>
+    <br>
+    <hr>
     <% @events.each do |event| %>
-      タイトル名：
-      <%= link_to event_path(event) do %>
-        <strong><%= event.title %></strong><br>
-      <% end %>
+      登録者：<%= event.user.name %><br>
+      タイトル名：<strong><%= event.title %></strong><br>
       内容：<%= event.content %><br>
       条件：<%= event.requirement %><br>
-      登録者：<%= event.user.name %><br>
-      参加登録<br>
-      <%= link_to "内容編集", edit_event_path(event.id), class: 'btn btn-default' %><br>
-      <%= link_to "削除", event_path(event.id), method: :delete, data: {confirm: '本当に削除していいですか？'}, class: 'btn btn-default btn-sm btn-danger' %><br>
-      <br>
-      <br>
-    <% end %>
-    <p>
-      <%= link_to "イベント新規登録", new_event_path, class: 'btn btn-default' %>
 
-    </p>
+      参加登録<br>
+      <%= link_to "参加者情報", event_path(event.id), class: 'btn btn-default' %>
+      <% if current_user.id == event.manager_id %>
+        <%= link_to "内容編集", edit_event_path(event.id), class: 'btn btn-default' %>
+        <%= link_to "削除", event_path(event.id), method: :delete, data: {confirm: '本当に削除していいですか？'}, class: 'btn btn-default btn-sm btn-danger' %><br>
+      <% end %>
+      <hr>
+    <% end %>
   </div>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,11 +8,16 @@
       <% end %>
       内容：<%= event.content %><br>
       条件：<%= event.requirement %><br>
-      参加登録
+      登録者：<%= event.user.name %><br>
+      参加登録<br>
+      <%= link_to "内容編集", edit_event_path(event.id), class: 'btn btn-default' %><br>
+      <%= link_to "削除", event_path(event.id), method: :delete, data: {confirm: '本当に削除していいですか？'}, class: 'btn btn-default btn-sm btn-danger' %><br>
+      <br>
+      <br>
     <% end %>
     <p>
       <%= link_to "イベント新規登録", new_event_path, class: 'btn btn-default' %>
-      編集・削除
+
     </p>
   </div>
 </div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,17 +1,6 @@
-new.html.erb
 <div class="container">
   <div class="row">
-    <%= form_for(@event) do |event| %>
-      <%= event.label :title %>
-      <%= event.text_field :title, class: 'form-control' %>
-      <br>
-      <%= event.label :content %>
-      <%= event.text_field :content, class: 'form-control' %>
-      <br>
-      <%= event.label :requirement %>
-      <%= event.text_field :requirement, class: 'form-control' %>
-      <br>
-      <%= event.submit '新規登録', class: 'btn btn-primary btn-block' %>
-    <% end %>
+    <h2>イベント新規登録</h2>
+    <%= render 'form' %>
   </div>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,20 @@
+<div class="container">
+  <div class="row">
+    <h1>イベント詳細ページ</h1>
+    登録者：<%= @event.user.name %><br>
+    タイトル名：
+    <%= link_to event_path(@event.id) do %>
+      <strong><%= @event.title %></strong><br>
+    <% end %>
+    内容：<%= @event.content %><br>
+    条件：<%= @event.requirement %><br>
+    <% if current_user.id == event.manager_id %>
+      <%= link_to "内容編集", edit_event_path(event.id), class: 'btn btn-default' %>
+      <%= link_to "削除", event_path(event.id), method: :delete, data: {confirm: '本当に削除していいですか？'}, class: 'btn btn-default btn-sm btn-danger' %><br>
+    <% end %>
+    <br>
+    参加登録<br>
+    参加登録者一覧<br>
+    <%= link_to '戻る', events_path %>
+  </div>
+</div>


### PR DESCRIPTION
#13-5

・eventコントローラーへ、edit,update,destroyアクション実装
編集画面、削除ボタンの実装
・コントローラー内で同一処理あり、リファクタリング実施
privateに以下を作成
event_params：ストロングパラメータ処理
set_event_id：idからのインスタンス変数化処理

をここまで目標17時00、
20分over

残りのshowアクション作成します