### PR TITLE
#15 参加登録機能用、コントローラー、モデル、テーブル作成

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,13 @@
+class RegistrationsController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
+
+  def edit
+  end
+
+  def update
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ActiveRecord::Base
   belongs_to :user, foreign_key: "manager_id"
+  has_many :registrations, dependent: :destroy
 
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,0 +1,4 @@
+class Registration < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable
 
   has_many :events, foreign_key: "manager_id"
+  has_many :registrations, dependent: :destroy
 end

--- a/app/views/registrations/create.html.erb
+++ b/app/views/registrations/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Registrations#create</h1>
+<p>Find me in app/views/registrations/create.html.erb</p>

--- a/app/views/registrations/destroy.html.erb
+++ b/app/views/registrations/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Registrations#destroy</h1>
+<p>Find me in app/views/registrations/destroy.html.erb</p>

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Registrations#edit</h1>
+<p>Find me in app/views/registrations/edit.html.erb</p>

--- a/app/views/registrations/update.html.erb
+++ b/app/views/registrations/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Registrations#update</h1>
+<p>Find me in app/views/registrations/update.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'top#index'
-  resources :events
+  resources :events do
+    resources :registrations, only: [:create, :destroy, :edit, :update]
+  end
   resources :users, only: [:show]
 end

--- a/db/migrate/20181005023606_create_registrations.rb
+++ b/db/migrate/20181005023606_create_registrations.rb
@@ -1,0 +1,13 @@
+class CreateRegistrations < ActiveRecord::Migration
+  def change
+    create_table :registrations do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :event, index: true, foreign_key: true
+      t.integer :desire_day
+      t.integer :desire_time
+      t.integer :on_requirement
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181002065054) do
+ActiveRecord::Schema.define(version: 20181005023606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,19 @@ ActiveRecord::Schema.define(version: 20181002065054) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
   end
+
+  create_table "registrations", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "event_id"
+    t.integer  "desire_day"
+    t.integer  "desire_time"
+    t.integer  "on_requirement"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
+
+  add_index "registrations", ["event_id"], name: "index_registrations_on_event_id", using: :btree
+  add_index "registrations", ["user_id"], name: "index_registrations_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -39,4 +52,6 @@ ActiveRecord::Schema.define(version: 20181002065054) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "registrations", "events"
+  add_foreign_key "registrations", "users"
 end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class RegistrationsControllerTest < ActionController::TestCase
+  test "should get create" do
+    get :create
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get :destroy
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get :edit
+    assert_response :success
+  end
+
+  test "should get update" do
+    get :update
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/registrations.yml
+++ b/test/fixtures/registrations.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 
+  event_id: 
+  desire_day: 1
+  desire_time: 1
+  on_requirement: 1
+
+two:
+  user_id: 
+  event_id: 
+  desire_day: 1
+  desire_time: 1
+  on_requirement: 1

--- a/test/models/registration_test.rb
+++ b/test/models/registration_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RegistrationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#15-1

イベント参加登録機能用
registrationsコントローラー
registrationモデル
registrasionsテーブル
を作成。

routes設定、eventへ登録のため
registrationsをeventsへネスト設定。

アソシエーション設定
users、eventsと多：多設定
双方、データ削除の際はレコード不要になるため、
user,eventへdependent destroyを設定

rake db:migrateの実行をお願いします。