### PR TITLE
#15-2 registrationsテーブル修正（2カラム変更）

### DIFF
--- a/app/assets/stylesheets/registration.css
+++ b/app/assets/stylesheets/registration.css
@@ -1,0 +1,11 @@
+ul{
+  padding: 0;
+}
+
+.right {
+text-align: right;
+}
+
+.left {
+text-align: left;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,6 +21,8 @@ class EventsController < ApplicationController
   end
 
   def show
+    @registration = @event.registrations.build
+    @registrations = @event.registrations
   end
 
   def edit

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,14 @@
 class RegistrationsController < ApplicationController
   def create
+    # @registration = current_user.registrations.build(params.permit(:event_id))
+    @registration = current_user.registrations.build(registrations_params)
+    @event = @registration.event
+
+    respond_to do |format|
+      if @registration.save
+        format.html { redirect_to event_path(@event), notice: '参加登録しました' }
+      end
+    end
   end
 
   def destroy
@@ -9,5 +18,10 @@ class RegistrationsController < ApplicationController
   end
 
   def update
+  end
+
+  private
+  def registrations_params
+    params.require(:registration).permit(:event_id, :desire_day, :desire_time, :on_requirement)
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,27 +1,32 @@
 class RegistrationsController < ApplicationController
   def create
-    # @registration = current_user.registrations.build(params.permit(:event_id))
-    @registration = current_user.registrations.build(registrations_params)
-    @event = @registration.event
+    @registration = current_user.registrations.build(registration_params)
+    set_event
 
     respond_to do |format|
       if @registration.save
-        format.html { redirect_to event_path(@event), notice: '参加登録しました' }
+        format.html { redirect_to event_path(@event), notice: "参加登録しました" }
+        format.js { render :index }
       end
     end
   end
 
   def destroy
-  end
-
-  def edit
-  end
-
-  def update
+    @registration = Registration.find(params[:id])
+    set_event
+    @registration.destroy
+    respond_to do |format|
+      format.html { redirect_to event_path(@event), notice: "参加登録をキャンセルしました" }
+      format.js { render :index }
+    end
   end
 
   private
-  def registrations_params
-    params.require(:registration).permit(:event_id, :desire_day, :desire_time, :on_requirement)
-  end
+    def registration_params
+      params.require(:registration).permit(:event_id, :start_datetime, :end_datetime, :on_requirement)
+    end
+
+    def set_event
+      @event = @registration.event
+    end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,23 +2,22 @@
   <div class="row">
     <h1>イベント詳細ページ</h1>
     <p id="notice"><%= notice %></p>
-    登録者：<%= @event.user.name %><br>
-    タイトル名：
-    <%= link_to event_path(@event.id) do %>
-      <strong><%= @event.title %></strong><br>
-    <% end %>
-    内容：<%= @event.content %><br>
-    条件：<%= @event.requirement %><br>
+    <p>登録者：<%= @event.user.name %><br></p>
+    <p>タイトル名：<strong><%= @event.title %></strong><br></p>
+    <p>内容：<%= @event.content %><br></p>
+    <p>条件：<%= @event.requirement %><br></p>
+    <p>作成日時：<%= @event.created_at.strftime("%y年%m月%d日 %p %l:%M") %></p>
     <% if current_user.id == @event.manager_id %>
       <%= link_to "内容編集", edit_event_path(@event.id), class: 'btn btn-default' %>
       <%= link_to "削除", event_path(@event.id), method: :delete, data: {confirm: '本当に削除していいですか？'}, class: 'btn btn-default btn-sm btn-danger' %><br>
     <% end %>
-    <br>
-    参加登録<br>
-    参加登録者一覧<br>
+    <hr>
+    参加登録者情報<br>
     <div id="registration_area">
       <%= render partial: 'registrations/index', locals: { registrations: @registrations, event: @event} %>
     </div>
+    <p>参加希望者は、下記フォームより登録してください</p>
+    <p>「開始しても良い」時間帯の登録でお願い致します。</p>
     <%= render partial: 'registrations/form', locals: { registration: @registration, event: @event } %>
     <%= link_to '戻る', events_path %>
   </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,6 +1,7 @@
 <div class="container">
   <div class="row">
     <h1>イベント詳細ページ</h1>
+    <p id="notice"><%= notice %></p>
     登録者：<%= @event.user.name %><br>
     タイトル名：
     <%= link_to event_path(@event.id) do %>
@@ -15,6 +16,10 @@
     <br>
     参加登録<br>
     参加登録者一覧<br>
+    <div id="registration_area">
+      <%= render partial: 'registrations/index', locals: { registrations: @registrations, event: @event} %>
+    </div>
+    <%= render partial: 'registrations/form', locals: { registration: @registration, event: @event } %>
     <%= link_to '戻る', events_path %>
   </div>
 </div>

--- a/app/views/events/update.js.erb
+++ b/app/views/events/update.js.erb
@@ -1,0 +1,1 @@
+<%= render 'save' %>

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for([event,registration]) do |f| %>
+<%= form_for([event,registration], remote: true) do |f| %>
   <% if registration.errors.any? %>
     <div id="error_explanation">
       <h2><%= registration.errors.count %>件のエラーがあります。</h2>
@@ -12,10 +12,11 @@
   <% end %>
   <%= f.hidden_field :event_id %>
   <div class="field">
-    <%= f.text_field :desire_day, placeholder: "時(0～23)", class: "form-control"  %>
-    <%= f.text_field :desire_time, placeholder: "分(0～59)", class: "form-control"  %>
+    <%= f.datetime_select :start_datetime, start_year: Time.now.year, end_year: Time.now.year, minute_step: 15 %>
+    ～
+    <%= f.datetime_select :end_datetime, start_year: Time.now.year, end_year: Time.now.year, minute_step: 15 %>
   </div>
   <div class="actions">
-    <%= f.submit %>
+    <%= f.submit '参加登録する' %>
   </div>
 <% end %>

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_for([event,registration]) do |f| %>
+  <% if registration.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= registration.errors.count %>件のエラーがあります。</h2>
+
+      <ul>
+      <% registration.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= f.hidden_field :event_id %>
+  <div class="field">
+    <%= f.text_field :desire_day, placeholder: "時(0～23)", class: "form-control"  %>
+    <%= f.text_field :desire_time, placeholder: "分(0～59)", class: "form-control"  %>
+  </div>
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/registrations/_index.html.erb
+++ b/app/views/registrations/_index.html.erb
@@ -2,14 +2,15 @@
   <% registrations.each do |registration| %>
     <% unless registration.id.nil? %>
       <li>
-        <p class="left"><%= registration.user.name %>さんがコメントしました。</p>
-        <p class="left"><%= registration.desire_day %></p>
-        <p class="left"><%= registration.desire_time %></p>
+        <div class="left">
+          <%= registration.user.name %>さん
+          <%= registration.start_datetime.strftime('%m月%d日 %H:%M') %>～
+          <%= registration.end_datetime.strftime('%m月%d日 %H:%M') %>
+        </div>
         <% if current_user.id == registration.user.id %>
-          <p class="right">
-            <%= link_to '', edit_event_registration_path(event, registration), class: "fa fa-pencil-square-o fa-lg" %>
+          <div class="right">
             <%= link_to '', event_registration_path(event, registration), class: "fa fa-trash-o fa-lg", method: :delete, remote: true, data: { confirm: '本当に削除していいですか？' } %>
-          </p>
+          </div>
         <% end %>
       </li>
     <% end %>

--- a/app/views/registrations/_index.html.erb
+++ b/app/views/registrations/_index.html.erb
@@ -1,0 +1,17 @@
+<ul>
+  <% registrations.each do |registration| %>
+    <% unless registration.id.nil? %>
+      <li>
+        <p class="left"><%= registration.user.name %>さんがコメントしました。</p>
+        <p class="left"><%= registration.desire_day %></p>
+        <p class="left"><%= registration.desire_time %></p>
+        <% if current_user.id == registration.user.id %>
+          <p class="right">
+            <%= link_to '', edit_event_registration_path(event, registration), class: "fa fa-pencil-square-o fa-lg" %>
+            <%= link_to '', event_registration_path(event, registration), class: "fa fa-trash-o fa-lg", method: :delete, remote: true, data: { confirm: '本当に削除していいですか？' } %>
+          </p>
+        <% end %>
+      </li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -1,2 +1,0 @@
-<h1>Registrations#edit</h1>
-<p>Find me in app/views/registrations/edit.html.erb</p>

--- a/app/views/registrations/index.js.erb
+++ b/app/views/registrations/index.js.erb
@@ -1,0 +1,1 @@
+$("#registration_area").html("<%= j(render 'registrations/index', { registrations: @registration.event.registrations, event: @registration.event }) %>")

--- a/app/views/registrations/update.html.erb
+++ b/app/views/registrations/update.html.erb
@@ -1,2 +1,0 @@
-<h1>Registrations#update</h1>
-<p>Find me in app/views/registrations/update.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'top#index'
   resources :events do
-    resources :registrations, only: [:create, :destroy, :edit, :update]
+    resources :registrations, only: [:create, :destroy]
   end
   resources :users, only: [:show]
 end

--- a/db/migrate/20181005023606_create_registrations.rb
+++ b/db/migrate/20181005023606_create_registrations.rb
@@ -3,8 +3,8 @@ class CreateRegistrations < ActiveRecord::Migration
     create_table :registrations do |t|
       t.references :user, index: true, foreign_key: true
       t.references :event, index: true, foreign_key: true
-      t.integer :desire_day
-      t.integer :desire_time
+      t.datetime :start_datetime
+      t.datetime :end_datetime
       t.integer :on_requirement
 
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,8 +28,8 @@ ActiveRecord::Schema.define(version: 20181005023606) do
   create_table "registrations", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "event_id"
-    t.integer  "desire_day"
-    t.integer  "desire_time"
+    t.datetime "start_datetime"
+    t.datetime "end_datetime"
     t.integer  "on_requirement"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false


### PR DESCRIPTION
#15-2

registrationsテーブル内の2カラムを変更
日時を扱うため、型の変更
参加可能な、開始時間～終了時間の2つが必要なためstartとendとした。
共にinteger型→datetime型
desire_day → start_datetime
desire_time → end_datetime

本来はマイグレーションファイル発行すると思われますが、
初期のマイグレーションファイルを修正しているため、
データベースのリセット、再構築をお願いします。